### PR TITLE
Updates to use new IoTConnect calls

### DIFF
--- a/avnet_rsl10_2devices/rsl10.c
+++ b/avnet_rsl10_2devices/rsl10.c
@@ -500,11 +500,9 @@ void rsl10SendTelemetry(void) {
                                                                    Rsl10DeviceList[currentDevice].lastOrientation_w);
 
                 Log_Debug("Send telemetry: %s\n", telemetryBuffer);
-
 #ifdef USE_IOT_CONNECT
 
-                // Send the telemetry message
-                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties,NULL);
+                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties, NULL);
 
 #else // !USE_IOT_CONNECT
 
@@ -536,21 +534,21 @@ void rsl10SendTelemetry(void) {
                                                                    Rsl10DeviceList[currentDevice].lastHumidity,
                                                                    Rsl10DeviceList[currentDevice].telemetryKey,
                                                                    Rsl10DeviceList[currentDevice].lastPressure);
+
                 Log_Debug("Send telemetry: %s\n", telemetryBuffer);
 
 #ifdef USE_IOT_CONNECT
 
-                // Send the telemetry message
-                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties,NULL);
+                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties, NULL);
 
 #else // !USE_IOT_CONNECT
 
                 // Send the telemetry message
                 dx_azurePublish(telemetryBuffer, strnlen(telemetryBuffer, JSON_BUFFER_SIZE),
                                     messageProperties, NELEMS(messageProperties),
-                                    &contentProperties);                
-#endif                 
-    
+                                    &contentProperties);     
+                
+#endif     
                 // Clear the flag so we don't send this data again
                 Rsl10DeviceList[currentDevice].movementDataRefreshed = false;
 
@@ -573,21 +571,21 @@ void rsl10SendTelemetry(void) {
                                                                    Rsl10DeviceList[currentDevice].lastRssi,
                                                                    Rsl10DeviceList[currentDevice].telemetryKey,
                                                                    Rsl10DeviceList[currentDevice].lastBattery);
+
                 Log_Debug("Send telemetry: %s\n", telemetryBuffer);
 
 #ifdef USE_IOT_CONNECT
 
-                // Send the telemetry message
-                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties,NULL);
+                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties, NULL);
 
 #else // !USE_IOT_CONNECT
 
                 // Send the telemetry message
                 dx_azurePublish(telemetryBuffer, strnlen(telemetryBuffer, JSON_BUFFER_SIZE),
                                     messageProperties, NELEMS(messageProperties),
-                                    &contentProperties);                
-#endif                 
-
+                                    &contentProperties);
+                
+#endif 
                 // Clear the flag so we don't send this data again
                 Rsl10DeviceList[currentDevice].batteryDataRefreshed = false;
 

--- a/avnet_sk_demo/build_options.h
+++ b/avnet_sk_demo/build_options.h
@@ -22,7 +22,6 @@
 // If this is a IoT Conect build, make sure to enable the IOT Hub application code
 #ifdef USE_IOT_CONNECT
 #define IOT_HUB_APPLICATION
-#define IOT_CONNECT_API_VERSION 1
 #undef USE_PNP // Disable PNP device twins responses
 #endif 
 

--- a/avnet_sk_demo/main.h
+++ b/avnet_sk_demo/main.h
@@ -76,9 +76,6 @@ DX_USER_CONFIG dx_config;
 #ifdef IOT_HUB_APPLICATION
 static char msgBuffer[JSON_MESSAGE_BYTES] = {0};
 #endif // IOT_HUB_APPLICATION        
-#ifdef USE_IOT_CONNECT
-static char avtMsgBuffer[JSON_MESSAGE_BYTES + DX_AVNET_IOT_CONNECT_METADATA] = {0};
-#endif //USE_IOT_CONNECT
 
 #ifdef IOT_HUB_APPLICATION
 static DX_MESSAGE_PROPERTY *messageProperties[] =   {&(DX_MESSAGE_PROPERTY){.key = "appid", .value = "SK-Demo"}, 


### PR DESCRIPTION
Update examples to use new dx_avnetPublish() calls to send telemetry to Avnet's IoTConnect Platform